### PR TITLE
Widok mobilny dla zakładki terminarza

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.0
+
+### (FEATURE) Widok mobilny dla terminarza
+
+* Dodano responsywny widok mobilny dla kart terminarza (`calendar-day` oraz `match-card`)
+* Dostosowanie rozmiarów czcionek, przycisków oraz paddingów do ekranów smartfonów
+* Zmniejszone logotypy i badge wyników na urządzeniach mobilnych
+
 ## 1.3.1
 
 ### (FIX) Porządki w strukturze projektu i stylach

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "match-planer",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -27,10 +27,12 @@ body {
   }
 
   @media (max-width: 767.98px) {
-    margin-left: 100px !important;
+    margin-left: 75px !important;
+    margin-right: -25px !important;
 
     &.collapsed {
-      margin-left: 100px !important;
+      margin-left: 75px !important;
+      margin-right: -25px !important;
     }
   }
 }

--- a/src/app/calendar/components/calendar-day/calendar-day.component.html
+++ b/src/app/calendar/components/calendar-day/calendar-day.component.html
@@ -3,7 +3,7 @@
     class="d-flex justify-content-between align-items-center card-title card-header bg-transparent fs-5 p-3"
   >
     <span>{{ date }}</span>
-    <button class="btn btn-link text-white p-0" (click)="toggle()">
+    <button class="btn btn-link text-white p-0 btn-sm" (click)="toggle()">
       <i
         class="fas"
         [ngClass]="{ 'fa-chevron-down': !expanded, 'fa-chevron-up': expanded }"

--- a/src/app/calendar/components/calendar-day/calendar-day.component.scss
+++ b/src/app/calendar/components/calendar-day/calendar-day.component.scss
@@ -1,3 +1,15 @@
 .card {
   border-radius: 8px;
 }
+
+@media (max-width: 767.98px) {
+  // Padding (p-3 to 1rem lub 16px)
+  h6.card-title {
+    padding: 0.8rem !important;
+  }
+
+  // Data (fs-5 to 1.25rem lub 20px)
+  .card-title span {
+    font-size: 1rem;
+  }
+}

--- a/src/app/calendar/components/match-card/match-card.component.html
+++ b/src/app/calendar/components/match-card/match-card.component.html
@@ -1,6 +1,6 @@
 <div class="card text-white m-1 match-card" (click)="onClick()">
-  <div class="card-body p-3">
-    <div class="d-flex justify-content-between align-items-center mb-2">
+  <div class="card-body p-2 p-md-3">
+    <div class="d-flex justify-content-between align-items-center mb-1 mb-md-2">
       <div class="d-flex align-items-center justify-content-start">
         <img
           *ngIf="match.logoA; else defaultLogoA"
@@ -11,11 +11,11 @@
         <ng-template #defaultLogoA>
           <i class="fas fa-tshirt team-logo"></i>
         </ng-template>
-        <span class="fw-semibold">{{ match.teamA }}</span>
+        <span class="fw-semibold team-name">{{ match.teamA }}</span>
       </div>
 
       <span
-        class="badge text-white px-3 py-2"
+        class="badge text-white px-2 px-md-3 py-1 py-md-2"
         [ngClass]="getBadgeClass(match.scoreA, match.scoreB)"
       >
         {{ match.scoreA }}
@@ -33,11 +33,11 @@
         <ng-template #defaultLogoB>
           <i class="fas fa-tshirt team-logo"></i>
         </ng-template>
-        <span class="fw-semibold">{{ match.teamB }}</span>
+        <span class="fw-semibold team-name">{{ match.teamB }}</span>
       </div>
 
       <span
-        class="badge text-white px-3 py-2"
+        class="badge text-white px-2 px-md-3 py-1 py-md-2"
         [ngClass]="getBadgeClass(match.scoreB, match.scoreA)"
       >
         {{ match.scoreB }}

--- a/src/app/calendar/components/match-card/match-card.component.scss
+++ b/src/app/calendar/components/match-card/match-card.component.scss
@@ -29,6 +29,43 @@
   font-size: 0.95rem;
 }
 
+.team-name {
+  font-size: 1rem;
+}
+
 .custom-group {
   color: $cards-text-information;
+}
+
+@media (max-width: 767.98px) {
+  // Nazwa drużyny (1rem na desktopowym)
+  .team-name {
+    font-size: 0.8rem;
+  }
+
+  // Nazwa grupy
+  // 0.875 * 16px = 14px lub 0.875rem (small)
+  .custom-group {
+    font-size: 0.7rem;
+  }
+
+  // Logo drużyny
+  .team-logo {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    margin-right: 8px;
+  }
+
+  // Ikona koszulki
+  .fas.fa-tshirt.team-logo {
+    font-size: 18px;
+    margin-right: 8px;
+    line-height: 25px;
+  }
+
+  // Rozmiar pastylki z wynikiem
+  .badge {
+    font-size: 0.8rem;
+  }
 }


### PR DESCRIPTION
* Dodano responsywny widok mobilny dla kart terminarza (`calendar-day` oraz `match-card`)
* Dostosowanie rozmiarów czcionek, przycisków oraz paddingów do ekranów smartfonów
* Zmniejszone logotypy i badge wyników na urządzeniach mobilnych
* Usprawnione czytelne wyświetlanie nazw drużyn i grup w widoku mobilnym